### PR TITLE
Update to Klavaro 3.12 & 20.08 runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.sourceforge.Klavaro.appdata.xml
+++ b/net.sourceforge.Klavaro.appdata.xml
@@ -32,5 +32,5 @@
   <releases>
     <release date="2019-06-21" version="3.08"/>
   </releases>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
 </component>

--- a/net.sourceforge.Klavaro.appdata.xml
+++ b/net.sourceforge.Klavaro.appdata.xml
@@ -30,6 +30,7 @@
   <url type="translate">http://klavaro.sourceforge.net/en/translation.html</url>
   <updatecontact>fefcas_at_gmail.com</updatecontact>
   <releases>
+    <release version="3.12" date="2021-04-14"/>
     <release date="2019-06-21" version="3.08"/>
   </releases>
   <content_rating type="oars-1.1"/>

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -15,6 +15,9 @@
     "modules": [
         {
             "name": "adwaita-icon-theme",
+            "cleanup": [
+                "/lib"
+            ],
             "sources": [
                 {
                     "x-checker-data": {

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -44,7 +44,8 @@
             ],
             "post-install": [
                 "rm -f /app/share/appdata/klavaro.appdata.xml",
-                "install -Dm644 net.sourceforge.Klavaro.appdata.xml /app/share/appdata/net.sourceforge.Klavaro.appdata.xml"
+                "install -Dm644 net.sourceforge.Klavaro.appdata.xml /app/share/appdata/net.sourceforge.Klavaro.appdata.xml",
+                "install -Dm644 data/icons/hicolor/48x48.svg /app/share/icons/hicolor/scalable/apps/net.sourceforge.Klavaro.svg"
             ],
             "sources": [
                 {

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -4,7 +4,7 @@
     "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "klavaro",
-    "finish-args":[
+    "finish-args": [
         "--socket=x11",
         "--share=ipc",
         "--socket=wayland",
@@ -12,7 +12,7 @@
     ],
     "rename-icon": "klavaro",
     "rename-desktop-file": "klavaro.desktop",
-    "modules":[
+    "modules": [
         {
             "name": "adwaita-icon-theme",
             "sources": [
@@ -38,7 +38,7 @@
                 "rm -f /app/share/appdata/klavaro.appdata.xml",
                 "install -Dm644 net.sourceforge.Klavaro.appdata.xml /app/share/appdata/net.sourceforge.Klavaro.appdata.xml"
             ],
-            "sources":[
+            "sources": [
                 {
                     "x-checker-data": {
                         "type": "html",

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -23,8 +23,8 @@
                         "stable-only": true
                     },
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.32/adwaita-icon-theme-3.32.0.tar.xz",
-                    "sha256": "698db6e407bb987baec736c6a30216dfc0317e3ca2403c7adf3a5aa46c193286"
+                    "url": "https://download.gnome.org/sources/adwaita-icon-theme/3.38/adwaita-icon-theme-3.38.0.tar.xz",
+                    "sha256": "6683a1aaf2430ccd9ea638dd4bfe1002bc92b412050c3dba20e480f979faaf97"
                 }
             ]
         },
@@ -47,8 +47,8 @@
                         "is-main-source": true
                     },
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/klavaro/klavaro-3.08.tar.bz2",
-                    "sha256": "2c6b0c2d0a7a6cb4c568d0c3a97267bf7fbac98b8b97b93bb81c6a8e9ac9bb62"
+                    "url": "https://sourceforge.net/projects/klavaro/files/klavaro-3.12.tar.bz2",
+                    "sha256": "c450e27f07d5e7d57818a5a8d428cacad7c17a28dcabe0c2e5694a4fe9abb97a"
                 },
                 {
                     "type": "file",

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -1,7 +1,7 @@
 {
     "id": "net.sourceforge.Klavaro",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
+    "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "klavaro",
     "finish-args":[

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -30,6 +30,28 @@
         },
         "shared-modules/intltool/intltool-0.51.json",
         {
+            "name": "gtkdatabox3",
+            "cleanup": [
+                "*.a",
+                "*.la",
+                "*.pc",
+                "/include",
+                "/share"
+            ],
+            "sources": [
+                {
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://sourceforge.net/projects/gtkdatabox3/rss",
+                        "pattern": "<link>(https://sourceforge.net/.+/gtkdatabox3-([\\d\\.]+\\d).tar.\\w+)/download</link>"
+                    },
+                    "type": "archive",
+                    "url": "https://sourceforge.net/projects/gtkdatabox3/files/gtkdatabox-1.0.0.tar.gz",
+                    "sha256": "7add2cd8fb4209f3970dbd33f5238e25b43f6251e7534607bf926c7c6175e14b"
+                }
+            ]
+        },
+        {
             "name": "klavaro",
             "cleanup": [
                 "*.a",

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -13,24 +13,6 @@
     "rename-icon": "klavaro",
     "rename-desktop-file": "klavaro.desktop",
     "modules": [
-        {
-            "name": "adwaita-icon-theme",
-            "cleanup": [
-                "/lib"
-            ],
-            "sources": [
-                {
-                    "x-checker-data": {
-                        "type": "gnome",
-                        "name": "adwaita-icon-theme",
-                        "stable-only": true
-                    },
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/adwaita-icon-theme/3.38/adwaita-icon-theme-3.38.0.tar.xz",
-                    "sha256": "6683a1aaf2430ccd9ea638dd4bfe1002bc92b412050c3dba20e480f979faaf97"
-                }
-            ]
-        },
         "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "gtkdatabox3",

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -28,6 +28,7 @@
                 }
             ]
         },
+        "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "klavaro",
             "cleanup": [

--- a/net.sourceforge.Klavaro.json
+++ b/net.sourceforge.Klavaro.json
@@ -17,6 +17,11 @@
             "name": "adwaita-icon-theme",
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "adwaita-icon-theme",
+                        "stable-only": true
+                    },
                     "type": "archive",
                     "url": "http://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.32/adwaita-icon-theme-3.32.0.tar.xz",
                     "sha256": "698db6e407bb987baec736c6a30216dfc0317e3ca2403c7adf3a5aa46c193286"
@@ -35,6 +40,12 @@
             ],
             "sources":[
                 {
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://sourceforge.net/projects/klavaro/rss",
+                        "pattern": "<link>(https://sourceforge.net/.+/klavaro-([\\d\\.]+\\d).tar.\\w+)/download</link>",
+                        "is-main-source": true
+                    },
                     "type": "archive",
                     "url": "https://downloads.sourceforge.net/klavaro/klavaro-3.08.tar.bz2",
                     "sha256": "2c6b0c2d0a7a6cb4c568d0c3a97267bf7fbac98b8b97b93bb81c6a8e9ac9bb62"


### PR DESCRIPTION
Quite by chance, .12 was released 2 days ago!

This PR also adds flatpak-external-data-checker config for the app and its dependencies.

Fixes #4 